### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,7 +18,7 @@ require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_log extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
        $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handle_action_act_preprocess');
        $controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, 'handle_cache_prepare');
     }

--- a/syntax.php
+++ b/syntax.php
@@ -27,7 +27,7 @@ class syntax_plugin_log extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{log(?:>[^}]+)?}}',$mode,'plugin_log');
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         global $ID;
 
         if (preg_match('/{{log(?:>(\d+))?}}/', $match, $match) === 0) {
@@ -96,7 +96,7 @@ class syntax_plugin_log extends DokuWiki_Syntax_Plugin {
                      $type, $logpage, $maxcount);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode === 'metadata'){
             $renderer->meta['relation']['logplugin'] = true;
             return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.